### PR TITLE
setup node in seperate deploy job to install firebase

### DIFF
--- a/.github/workflows/deploy-cargonaut.yml
+++ b/.github/workflows/deploy-cargonaut.yml
@@ -9,6 +9,11 @@ jobs:
         steps:
             - name: Checkout Repo
               uses: actions/checkout@v2
+            - name: Use Node.js 14
+              uses: actions/setup-node@v2
+              with:
+                  node-version: 14
+                  cache: 'npm'
             - name: Cache
               uses: actions/cache@v2
               with:
@@ -19,8 +24,5 @@ jobs:
                   restore-keys: |
                       ${{ runner.os }}-node-
             - name: Deploy to Firebase
-              uses: w9jds/firebase-action@master
-              with:
-                args: deploy --only hosting
-              env:
-                FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}
+            - run: npm i -g firebase-tools
+            - run: firebase deploy --token ${{ secrets.FIREBASE_TOKEN }}


### PR DESCRIPTION
- cache instead of using artifacts
- setup node in seperate deploy job to install firebase
