### PR TITLE
skip cache on build in ci

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
         "all:e2e": "nx run-many --target=e2e --all --parallel --skip-nx-cache",
         "ci:lint": "nx affected --target=lint --parallel --max-parallel=3",
         "ci:test": "nx affected --target=test --parallel  --max-parallel=3",
-        "ci:build": "nx affected --target=build --parallel  --max-parallel=3",
+        "ci:build": "nx affected --target=build --parallel  --max-parallel=3 --skip-nx-cache",
         "ci:doc": "nx affected --target=compodoc --parallel  --max-parallel=3",
         "ci:e2e": "nx affected --target=e2e --parallel  --max-parallel=3",
         "format": "nx format:write",


### PR DESCRIPTION
- Added cargonaut.drawio
- update ci for greater speed
- add doc to cacheable operations
- remove 1 from agent name to avoid redundance
- agents add the end of pipeline config file
- start and stop ci agents
- fix typo
- try fix ci
- skip cache on build to actually build
